### PR TITLE
added missing jquery ui to modman

### DIFF
--- a/modman
+++ b/modman
@@ -5,6 +5,7 @@ src/app/etc/modules/* app/etc/modules
 src/js/tablekit/tablekit.js js/tablekit/tablekit.js
 src/js/mep/* js/mep
 src/skin/adminhtml/default/default/jquery.min.js skin/adminhtml/default/default/jquery.min.js
+src/skin/adminhtml/default/default/jqueryui skin/adminhtml/default/default/jqueryui
 src/skin/adminhtml/default/default/mep.css skin/adminhtml/default/default
 src/skin/adminhtml/default/default/mep.js skin/adminhtml/default/default
 src/skin/adminhtml/default/default/tablekit.css skin/adminhtml/default/default


### PR DESCRIPTION
Hi,
jQuery UI directory was missing from the modman file. I've added this.
Kind regards,
Alan